### PR TITLE
LOG-1796:Allow reduce transformation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,8 +3248,6 @@ dependencies = [
 [[package]]
 name = "hyper-openssl"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
 dependencies = [
  "http",
  "hyper",
@@ -3261,6 +3259,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tower-layer",
+ "tracing 0.1.36",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,6 +376,7 @@ ocp-logging = [
   "transforms-remap",
   "transforms-lua",
   "transforms-throttle",
+  "transforms-reduce",
 
   "vrl-cli",
 


### PR DESCRIPTION
This is need to resolve issue https://issues.redhat.com/browse/LOG-1796.
`reduce transformation` will use for merging multiline logs to the one event. 
More information here:

- [Reduce: Vector Doc](https://vector.dev/docs/reference/configuration/transforms/reduce/)
- vectordotdev/vector#4211 
- vectordotdev/vector#4258

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
