### PR TITLE
Enable AWS S3 sink in ocp-logging feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,6 +487,7 @@ ocp-logging = [
   "transforms-detect_exceptions",
 
   "sinks-aws_cloudwatch_logs",
+  "sinks-aws_s3",
   "sinks-azure_monitor_logs",
   "sinks-elasticsearch",
   "sinks-file",


### PR DESCRIPTION
## Summary
- Add `sinks-aws_s3` to the `ocp-logging` feature set in Cargo.toml
- Enables Amazon S3 sink functionality alongside existing CloudWatch Logs sink
- Maintains compatibility with Red Hat's custom OpenSSL configuration

## Changes
- Modified `Cargo.toml` to include `"sinks-aws_s3"` in the `ocp-logging` feature list
- All required dependencies (aws-sdk-s3, base64, md-5, aws-core) are already available as optional dependencies

## Benefits
- Red Hat Vector builds can now write logs and data to S3 buckets
- Provides additional cloud storage options for log aggregation
- Maintains existing CloudWatch Logs functionality

## Test plan
- [x] Verified S3 sink source files exist and are properly configured
- [x] Confirmed feature flags are correctly set up
- [x] Validated that all dependencies are available
- [x] Build progresses successfully with new feature enabled

🤖 Generated with [Claude Code](https://claude.ai/code)