### PR TITLE
NO-JIRA:apply cargo clippy fixes across codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6974,7 +6974,6 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/lib/codecs/src/encoding/format/mod.rs
+++ b/lib/codecs/src/encoding/format/mod.rs
@@ -14,8 +14,8 @@ mod native;
 mod native_json;
 mod protobuf;
 mod raw_message;
-mod text;
 mod syslog;
+mod text;
 
 use std::fmt::Debug;
 
@@ -30,8 +30,8 @@ pub use native::{NativeSerializer, NativeSerializerConfig};
 pub use native_json::{NativeJsonSerializer, NativeJsonSerializerConfig};
 pub use protobuf::{ProtobufSerializer, ProtobufSerializerConfig, ProtobufSerializerOptions};
 pub use raw_message::{RawMessageSerializer, RawMessageSerializerConfig};
-pub use text::{TextSerializer, TextSerializerConfig};
 pub use syslog::{SyslogSerializer, SyslogSerializerConfig};
+pub use text::{TextSerializer, TextSerializerConfig};
 use vector_core::event::Event;
 
 /// Serialize a structured event into a byte frame.

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -13,8 +13,8 @@ pub use format::{
     JsonSerializer, JsonSerializerConfig, JsonSerializerOptions, LogfmtSerializer,
     LogfmtSerializerConfig, NativeJsonSerializer, NativeJsonSerializerConfig, NativeSerializer,
     NativeSerializerConfig, ProtobufSerializer, ProtobufSerializerConfig,
-    ProtobufSerializerOptions, RawMessageSerializer, RawMessageSerializerConfig, TextSerializer,
-    TextSerializerConfig, SyslogSerializer, SyslogSerializerConfig
+    ProtobufSerializerOptions, RawMessageSerializer, RawMessageSerializerConfig, SyslogSerializer,
+    SyslogSerializerConfig, TextSerializer, TextSerializerConfig,
 };
 pub use framing::{
     BoxedFramer, BoxedFramingError, BytesEncoder, BytesEncoderConfig, CharacterDelimitedEncoder,
@@ -268,7 +268,7 @@ pub enum SerializerConfig {
 
     /// Syslog encoding
     /// RFC 3164 and 5424 are supported
-    Syslog (SyslogSerializerConfig)
+    Syslog(SyslogSerializerConfig),
 }
 
 impl From<AvroSerializerConfig> for SerializerConfig {
@@ -394,7 +394,7 @@ impl SerializerConfig {
             | SerializerConfig::NativeJson
             | SerializerConfig::RawMessage
             | SerializerConfig::Text(_) => FramingConfig::NewlineDelimited,
-            | SerializerConfig::Syslog(_) => FramingConfig::NewlineDelimited,
+            SerializerConfig::Syslog(_) => FramingConfig::NewlineDelimited,
             SerializerConfig::Gelf => {
                 FramingConfig::CharacterDelimited(CharacterDelimitedEncoderConfig::new(0))
             }

--- a/lib/vector-core/src/tls/mod.rs
+++ b/lib/vector-core/src/tls/mod.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, net::SocketAddr, path::PathBuf, time::Duration};
 
 use openssl::{
     error::ErrorStack,
-    ssl::{ConnectConfiguration, SslConnector, SslConnectorBuilder, SslMethod, ErrorEx},
+    ssl::{ConnectConfiguration, ErrorEx, SslConnector, SslConnectorBuilder, SslMethod},
 };
 use snafu::{ResultExt, Snafu};
 use std::num::TryFromIntError;
@@ -184,13 +184,13 @@ pub fn tls_connector_builder(settings: &MaybeTlsSettings) -> Result<SslConnector
     let mut builder = SslConnector::builder(SslMethod::tls()).context(TlsBuildConnectorSnafu)?;
     if let Some(settings) = settings.tls() {
         settings.apply_context(&mut builder)?;
-        builder.set_min_tls_version_and_ciphersuites(&settings.min_tls_version, &settings.ciphersuites)
-        .map_err(|error_ex| match error_ex {
-             ErrorEx::OpenSslError{error_stack: e} => TlsError::SslBuildError { source:e },
-             ErrorEx::InvalidTlsVersion => TlsError::InvalidTlsVersion,
-             ErrorEx::InvalidCiphersuite => TlsError::InvalidCiphersuite,
-            }
-        )?;
+        builder
+            .set_min_tls_version_and_ciphersuites(&settings.min_tls_version, &settings.ciphersuites)
+            .map_err(|error_ex| match error_ex {
+                ErrorEx::OpenSslError { error_stack: e } => TlsError::SslBuildError { source: e },
+                ErrorEx::InvalidTlsVersion => TlsError::InvalidTlsVersion,
+                ErrorEx::InvalidCiphersuite => TlsError::InvalidCiphersuite,
+            })?;
     }
     Ok(builder)
 }

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -501,7 +501,7 @@ mod source {
         pub file: &'a Path,
     }
 
-    impl<'a> InternalEvent for GaveUpOnDeletedFile<'a> {
+    impl InternalEvent for GaveUpOnDeletedFile<'_> {
         fn emit(self) {
             info!(
                 message = "Gave up on deleted file.",
@@ -511,10 +511,9 @@ mod source {
                 "files_deleted_given_up_total",
                 "file" => self.file.to_string_lossy().into_owned(),
             )
-                .increment(1);
+            .increment(1);
         }
     }
-
 
     #[derive(Clone)]
     pub struct FileSourceInternalEventsEmitter {

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -18,7 +18,7 @@ pub struct KubernetesLogsEventsReceived<'a> {
 pub struct KubernetesLogsPodInfo {
     pub name: String,
     pub namespace: String,
-    pub container_name: String
+    pub container_name: String,
 }
 
 impl InternalEvent for KubernetesLogsEventsReceived<'_> {
@@ -40,14 +40,14 @@ impl InternalEvent for KubernetesLogsEventsReceived<'_> {
                     "pod_namespace" => pod_namespace.clone(),
                     "container_name" => container_name.clone(),
                 )
-                    .increment(1);
+                .increment(1);
                 counter!(
                     "component_received_event_bytes_total",
                     "pod_name" => pod_name.clone(),
                     "pod_namespace" => pod_namespace.clone(),
                     "container_name" => container_name.clone(),
                 )
-                    .increment(self.byte_size.get() as u64);
+                .increment(self.byte_size.get() as u64);
                 counter!("events_in_total", "pod_name" => pod_name, "pod_namespace" => pod_namespace, "container_name" => container_name.clone()).increment(1);
             }
             None => {

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -40,6 +40,8 @@ mod datadog_traces;
 mod dedupe;
 #[cfg(feature = "sources-demo_logs")]
 mod demo_logs;
+#[cfg(feature = "transforms-detect_exceptions")]
+pub mod detect_exceptions;
 #[cfg(feature = "sources-dnstap")]
 mod dnstap;
 #[cfg(feature = "sources-docker_logs")]
@@ -108,8 +110,6 @@ mod pulsar;
 mod redis;
 #[cfg(feature = "transforms-impl-reduce")]
 mod reduce;
-#[cfg(feature = "transforms-detect_exceptions")]
-pub mod detect_exceptions;
 mod remap;
 mod sample;
 #[cfg(feature = "sinks-sematext")]

--- a/src/secrets/file.rs
+++ b/src/secrets/file.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
+use std::io::{ErrorKind, Read};
 use std::path::Path;
-use std::io::{Read, ErrorKind};
 
 use vector_lib::configurable::{component::GenerateConfig, configurable_component};
 
@@ -20,17 +20,17 @@ impl GenerateConfig for FileBackend {
         toml::Value::try_from(FileBackend {
             base_path: String::from("/path/to/secrets"),
         })
-            .unwrap()
+        .unwrap()
     }
 }
 
 impl SecretBackend for FileBackend {
-   async fn retrieve(
+    async fn retrieve(
         &mut self,
         secret_keys: HashSet<String>,
         _signal_rx: &mut signal::SignalRx,
     ) -> crate::Result<HashMap<String, String>> {
-        return retrieve_secrets(&self.base_path, secret_keys);
+        retrieve_secrets(&self.base_path, secret_keys)
     }
 }
 
@@ -93,7 +93,10 @@ mod tests {
 
         let result = retrieve_secrets(&base_path, secret_keys);
         let error = result.expect_err("absolute key should produce error");
-        assert_eq!(error.to_string(), "secret key can not be absolute: /absolute/path");
+        assert_eq!(
+            error.to_string(),
+            "secret key can not be absolute: /absolute/path"
+        );
     }
 
     #[test]
@@ -115,6 +118,9 @@ mod tests {
 
         let result = retrieve_secrets(&base_path, secret_keys);
         let error = result.expect_err("secret should not be found");
-        assert_eq!(error.to_string(), "secret file for 'does_not_exist' not found");
+        assert_eq!(
+            error.to_string(),
+            "secret file for 'does_not_exist' not found"
+        );
     }
 }

--- a/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
@@ -33,14 +33,18 @@ pub struct FieldsSpec {
     #[configurable(metadata(docs::examples = "k8s.ns_uid"))]
     #[configurable(metadata(docs::examples = ""))]
     pub namespace_uid: OptionalTargetPath,
-
 }
 
 impl Default for FieldsSpec {
     fn default() -> Self {
         Self {
-            namespace_labels: OwnedTargetPath::event(owned_value_path!("kubernetes", "namespace_labels")).into(),
-            namespace_uid: OwnedTargetPath::event(owned_value_path!("kubernetes", "namespace_uid")).into(),
+            namespace_labels: OwnedTargetPath::event(owned_value_path!(
+                "kubernetes",
+                "namespace_labels"
+            ))
+            .into(),
+            namespace_uid: OwnedTargetPath::event(owned_value_path!("kubernetes", "namespace_uid"))
+                .into(),
         }
     }
 }
@@ -107,7 +111,8 @@ fn annotate_from_metadata(
         }
     }
     if let Some(uid) = &metadata.uid {
-        let legacy_key = fields_spec.namespace_uid
+        let legacy_key = fields_spec
+            .namespace_uid
             .path
             .as_ref()
             .map(|k| &k.path)
@@ -156,7 +161,10 @@ mod tests {
                 },
                 {
                     let mut log = LogEvent::default();
-                    log.insert(metadata_path!("kubernetes_logs", "namespace_uid"), "sandbox0-uid");
+                    log.insert(
+                        metadata_path!("kubernetes_logs", "namespace_uid"),
+                        "sandbox0-uid",
+                    );
                     log.insert(
                         metadata_path!("kubernetes_logs", "namespace_labels", "sandbox0-label0"),
                         "val0",
@@ -247,7 +255,10 @@ mod tests {
                 },
                 {
                     let mut log = LogEvent::default();
-                    log.insert(metadata_path!("kubernetes_logs", "namespace_uid"), "sandbox0-uid");
+                    log.insert(
+                        metadata_path!("kubernetes_logs", "namespace_uid"),
+                        "sandbox0-uid",
+                    );
                     log.insert(
                         metadata_path!("kubernetes_logs", "namespace_labels", "nested0.label0"),
                         "val0",

--- a/src/transforms/detect_exceptions/rules.rs
+++ b/src/transforms/detect_exceptions/rules.rs
@@ -51,7 +51,11 @@ pub struct Rule<'a> {
     pub to_state: ExceptionState,
 }
 
-fn rule(from_states: Vec<ExceptionState>, pattern_str: &str, to_state: ExceptionState) -> Rule {
+const fn rule(
+    from_states: Vec<ExceptionState>,
+    pattern_str: &str,
+    to_state: ExceptionState,
+) -> Rule {
     Rule {
         from_states,
         pattern: pattern_str,


### PR DESCRIPTION
This PR applies a series of Clippy-driven cleanups across the codebase to improve Rust best practices.
Also apply `cargo fmt --all` for codebase

/cc @Clee2691 @cahartma 
