### PR TITLE
[v0.37.1]LOG-7436:buffer_id handling in buffer usage metrics reporting

### DIFF
--- a/lib/vector-buffers/src/buffer_usage_data.rs
+++ b/lib/vector-buffers/src/buffer_usage_data.rs
@@ -242,8 +242,10 @@ impl BufferUsage {
     /// The `buffer_id` should be a unique name -- ideally the `component_id` of the sink using this buffer -- but is
     /// not used for anything other than reporting, and so has no _requirement_ to be unique.
     pub fn install(self, buffer_id: &str) {
+        let buffer_id = buffer_id.to_string();
         let span = self.span;
         let stages = self.stages;
+        let task_name = format!("buffer usage reporter ({buffer_id})");
 
         let task = async move {
             let mut interval = interval(Duration::from_secs(2));
@@ -264,6 +266,7 @@ impl BufferUsage {
                     let received = stage.received.consume();
                     if received.has_updates() {
                         emit(BufferEventsReceived {
+                            buffer_id: buffer_id.clone(),
                             idx: stage.idx,
                             count: received.event_count,
                             byte_size: received.event_byte_size,
@@ -273,6 +276,7 @@ impl BufferUsage {
                     let sent = stage.sent.consume();
                     if sent.has_updates() {
                         emit(BufferEventsSent {
+                            buffer_id: buffer_id.clone(),
                             idx: stage.idx,
                             count: sent.event_count,
                             byte_size: sent.event_byte_size,
@@ -282,6 +286,7 @@ impl BufferUsage {
                     let dropped = stage.dropped.consume();
                     if dropped.has_updates() {
                         emit(BufferEventsDropped {
+                            buffer_id: buffer_id.clone(),
                             idx: stage.idx,
                             intentional: false,
                             reason: "corrupted_events",
@@ -293,6 +298,7 @@ impl BufferUsage {
                     let dropped_intentional = stage.dropped_intentional.consume();
                     if dropped_intentional.has_updates() {
                         emit(BufferEventsDropped {
+                            buffer_id: buffer_id.clone(),
                             idx: stage.idx,
                             intentional: true,
                             reason: "drop_newest",
@@ -304,7 +310,6 @@ impl BufferUsage {
             }
         };
 
-        let task_name = format!("buffer usage reporter ({buffer_id})");
         spawn_named(task.instrument(span.or_current()), task_name.as_str());
     }
 }

--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -11,7 +11,7 @@ use vector_common::{
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref BUFFER_COUNTERS: DashMap<usize, (AtomicI64, AtomicI64)> = DashMap::new();
+    static ref BUFFER_COUNTERS: DashMap<(String, usize), (AtomicI64, AtomicI64)> = DashMap::new();
 }
 
 fn update_and_get(counter: &AtomicI64, delta: i64) -> i64 {
@@ -26,16 +26,23 @@ fn update_and_get(counter: &AtomicI64, delta: i64) -> i64 {
     new_val
 }
 
-fn update_buffer_gauge(stage: usize, events_delta: i64, bytes_delta: i64) {
+fn update_buffer_gauge(buffer_id: &str, stage: usize, events_delta: i64, bytes_delta: i64) {
     let counters = BUFFER_COUNTERS
-        .entry(stage)
+        .entry((buffer_id.to_string(), stage))
         .or_insert_with(|| (AtomicI64::new(0), AtomicI64::new(0)));
 
     let new_events = update_and_get(&counters.0, events_delta);
     let new_bytes = update_and_get(&counters.1, bytes_delta);
 
-    gauge!("buffer_events", i64_to_f64_safe(new_events), "stage" => stage.to_string());
-    gauge!("buffer_byte_size", i64_to_f64_safe(new_bytes), "stage" => stage.to_string());
+    gauge!("buffer_events", i64_to_f64_safe(new_events),
+        "buffer_id" => buffer_id.to_string(),
+        "stage" => stage.to_string()
+    );
+
+    gauge!("buffer_byte_size", i64_to_f64_safe(new_bytes),
+        "buffer_id" => buffer_id.to_string(),
+        "stage" => stage.to_string()
+    );
 }
 
 pub struct BufferCreated {
@@ -50,12 +57,13 @@ impl InternalEvent for BufferCreated {
             gauge!("buffer_max_event_size", u64_to_f64_safe(self.max_size_events as u64), "stage" => self.idx.to_string());
         }
         if self.max_size_bytes != 0 {
-            gauge!("buffer_max_byte_size", u64_to_f64_safe(self.max_size_bytes), "stage" => self.idx.to_string());
+            gauge!("buffer_max_byte_size", u64_to_f64_safe(self.max_size_events as u64), "stage" => self.idx.to_string());
         }
     }
 }
 
 pub struct BufferEventsReceived {
+    pub buffer_id: String,
     pub idx: usize,
     pub count: u64,
     pub byte_size: u64,
@@ -63,16 +71,24 @@ pub struct BufferEventsReceived {
 
 impl InternalEvent for BufferEventsReceived {
     fn emit(self) {
-        counter!("buffer_received_events_total", self.count, "stage" => self.idx.to_string());
-        counter!("buffer_received_bytes_total", self.byte_size, "stage" => self.idx.to_string());
+        counter!("buffer_received_events_total", self.count,
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        );
+
+        counter!("buffer_received_bytes_total", self.byte_size,
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        );
 
         let count_delta = i64::try_from(self.count).unwrap_or(i64::MAX);
         let bytes_delta = i64::try_from(self.byte_size).unwrap_or(i64::MAX);
-        update_buffer_gauge(self.idx, count_delta, bytes_delta);
+        update_buffer_gauge(&self.buffer_id, self.idx, count_delta, bytes_delta);
     }
 }
 
 pub struct BufferEventsSent {
+    pub buffer_id: String,
     pub idx: usize,
     pub count: u64,
     pub byte_size: u64,
@@ -80,16 +96,23 @@ pub struct BufferEventsSent {
 
 impl InternalEvent for BufferEventsSent {
     fn emit(self) {
-        counter!("buffer_sent_events_total", self.count, "stage" => self.idx.to_string());
-        counter!("buffer_sent_bytes_total", self.byte_size, "stage" => self.idx.to_string());
+        counter!("buffer_sent_events_total", self.count,
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        );
+
+        counter!("buffer_sent_bytes_total", self.byte_size,
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string());
 
         let count_delta = i64::try_from(self.count).unwrap_or(i64::MAX);
         let bytes_delta = i64::try_from(self.byte_size).unwrap_or(i64::MAX);
-        update_buffer_gauge(self.idx, -count_delta, -bytes_delta);
+        update_buffer_gauge(&self.buffer_id, self.idx, -count_delta, -bytes_delta);
     }
 }
 
 pub struct BufferEventsDropped {
+    pub buffer_id: String,
     pub idx: usize,
     pub count: u64,
     pub byte_size: u64,
@@ -106,6 +129,7 @@ impl InternalEvent for BufferEventsDropped {
                 count = %self.count,
                 intentional = %intentional_str,
                 reason = %self.reason,
+                buffer_id = %self.buffer_id,
                 stage = %self.idx,
             );
         } else {
@@ -114,14 +138,21 @@ impl InternalEvent for BufferEventsDropped {
                 count = %self.count,
                 intentional = %intentional_str,
                 reason = %self.reason,
+                buffer_id = %self.buffer_id,
                 stage = %self.idx,
             );
         }
-        counter!("buffer_discarded_events_total", self.count, "intentional" => intentional_str);
+
+        counter!(
+            "buffer_discarded_events_total", self.count,
+            "buffer_id" => self.buffer_id.clone(),
+            "intentional" => intentional_str,
+        );
 
         let count_delta = i64::try_from(self.count).unwrap_or(i64::MAX);
         let bytes_delta = i64::try_from(self.byte_size).unwrap_or(i64::MAX);
-        update_buffer_gauge(self.idx, -count_delta, -bytes_delta);
+
+        update_buffer_gauge(&self.buffer_id, self.idx, -count_delta, -bytes_delta);
     }
 }
 
@@ -164,10 +195,10 @@ registered_event! {
 mod tests {
     use super::*;
     use crate::cast_utils::F64_SAFE_INT_MAX;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
     use std::sync::Mutex;
     use std::thread;
-    use std::time::{Duration, Instant};
-    use metrics_util::debugging::{DebuggingRecorder, DebugValue};
+    use std::time::Instant;
 
 
     lazy_static! {
@@ -178,8 +209,8 @@ mod tests {
         BUFFER_COUNTERS.clear();
     }
 
-    fn get_counter_values(stage: usize) -> (i64, i64) {
-        match BUFFER_COUNTERS.get(&stage) {
+    fn get_counter_values(buffer_id: &str, stage: usize) -> (i64, i64) {
+        match BUFFER_COUNTERS.get(&(buffer_id.to_string(), stage)) {
             Some(counters) => {
                 let events = counters.0.load(Ordering::Relaxed);
                 let bytes = counters.1.load(Ordering::Relaxed);
@@ -192,11 +223,14 @@ mod tests {
 
     #[test]
     fn test_increment() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         reset_counters();
 
-        update_buffer_gauge(0, 10, 1024);
-        let (events, bytes) = get_counter_values(0);
+        update_buffer_gauge("test_buffer", 0, 10, 1024);
+        let (events, bytes) = get_counter_values("test_buffer", 0);
         assert_eq!(events, 10);
         assert_eq!(bytes, 1024);
     }
@@ -206,9 +240,9 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         reset_counters();
 
-        update_buffer_gauge(1, 100, 2048);
-        update_buffer_gauge(1, -50, -1024);
-        let (events, bytes) = get_counter_values(1);
+        update_buffer_gauge("test_buffer", 1, 100, 2048);
+        update_buffer_gauge("test_buffer", 1, -50, -1024);
+        let (events, bytes) = get_counter_values("test_buffer", 1);
         assert_eq!(events, 50);
         assert_eq!(bytes, 1024);
     }
@@ -218,9 +252,9 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         reset_counters();
 
-        update_buffer_gauge(2, 5, 100);
-        update_buffer_gauge(2, -10, -200);
-        let (events, bytes) = get_counter_values(2);
+        update_buffer_gauge("test_buffer", 2, 5, 100);
+        update_buffer_gauge("test_buffer", 2, -10, -200);
+        let (events, bytes) = get_counter_values("test_buffer", 2);
 
         assert_eq!(events, 0);
         assert_eq!(bytes, 0);
@@ -231,10 +265,10 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         reset_counters();
 
-        update_buffer_gauge(0, 10, 100);
-        update_buffer_gauge(1, 20, 200);
-        let (events0, bytes0) = get_counter_values(0);
-        let (events1, bytes1) = get_counter_values(1);
+        update_buffer_gauge("test_buffer", 0, 10, 100);
+        update_buffer_gauge("test_buffer", 1, 20, 200);
+        let (events0, bytes0) = get_counter_values("test_buffer", 0);
+        let (events1, bytes1) = get_counter_values("test_buffer", 1);
         assert_eq!(events0, 10);
         assert_eq!(bytes0, 100);
         assert_eq!(events1, 20);
@@ -243,7 +277,10 @@ mod tests {
 
     #[test]
     fn test_multithreaded_updates_are_correct() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         reset_counters();
 
         let num_threads = 10;
@@ -253,7 +290,7 @@ mod tests {
         for _ in 0..num_threads {
             let handle = thread::spawn(move || {
                 for _ in 0..increments_per_thread {
-                    update_buffer_gauge(0, 1, 10);
+                    update_buffer_gauge("test_buffer", 0, 1, 10);
                 }
             });
             handles.push(handle);
@@ -263,7 +300,7 @@ mod tests {
             handle.join().unwrap();
         }
 
-        let (final_events, final_bytes) = get_counter_values(0);
+        let (final_events, final_bytes) = get_counter_values("test_buffer", 0);
         let expected_events = i64::from(num_threads * increments_per_thread);
         let expected_bytes = i64::from(num_threads * increments_per_thread * 10);
 
@@ -273,12 +310,15 @@ mod tests {
 
     #[test]
     fn test_large_values_capped_to_f64_safe_max() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         reset_counters();
 
-        update_buffer_gauge(3, F64_SAFE_INT_MAX * 2, F64_SAFE_INT_MAX * 2);
+        update_buffer_gauge("test_buffer", 3, F64_SAFE_INT_MAX * 2, F64_SAFE_INT_MAX * 2);
 
-        let (events, bytes) = get_counter_values(3);
+        let (events, bytes) = get_counter_values("test_buffer", 3);
 
         assert!(events > F64_SAFE_INT_MAX);
         assert!(bytes > F64_SAFE_INT_MAX);
@@ -335,13 +375,13 @@ mod tests {
         };
 
         reset_counters();
-        update_buffer_gauge(0, 100, 1024);
-        update_buffer_gauge(0, -200, -4096);
+        update_buffer_gauge("test_buffer", 0, 100, 1024);
+        update_buffer_gauge("test_buffer", 0, -200, -4096);
         assert_final_gauge_state(0, 0.0, 0.0);
 
         reset_counters();
-        update_buffer_gauge(0, 100, 2048);
-        update_buffer_gauge(0, 200, 1024);
+        update_buffer_gauge("test_buffer", 0, 100, 2048);
+        update_buffer_gauge("test_buffer", 0, 200, 1024);
         assert_final_gauge_state(0, 300.0, 3072.0);
     }
 }


### PR DESCRIPTION
back-port https://github.com/ViaQ/vector/pull/223

/cc @Clee2691 @cahartma 
/assign @jcantrill 