### PR TITLE
LOG-7812: Enable transform log_to_metric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -480,10 +480,10 @@ ocp-logging = [
   "transforms-dedupe",
   "transforms-filter",
   "transforms-remap",
+  "transforms-log_to_metric",
   "transforms-lua",
   "transforms-throttle",
   "transforms-reduce",
-
   "transforms-detect_exceptions",
 
   "sinks-aws_cloudwatch_logs",


### PR DESCRIPTION
This PR:
* Enables the log_to_metric transform so we can track unmatched logs as a metric

cc @vparfonov @cahartma @Clee2691 