### PR TITLE
Install systemd manually in ART-built image

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -20,6 +20,7 @@ RUN cp /opt/app-root/src/target/release/vector /usr/bin
 FROM registry.redhat.io/rhel9-6-els/rhel:9.6@sha256:79408df6a94a716af2f2bd6aff681e33c7c91691ac128a0c5fb90b423dbd48ad
 
 COPY --from=builder /usr/bin/vector /usr/bin/
+RUN dnf install -y systemd
 
 WORKDIR /usr/bin
 CMD ["/usr/bin/vector"]


### PR DESCRIPTION
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Foadp/982/console

https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/art-logging-tenant/applications/logging-6-3/pipelineruns/logging-6-3-vector-vgvz9

```
$ podman run -it --entrypoint=/usr/bin/journalctl quay.io...:vector-rhel9-6.3.3-20260122.215503 --version

systemd 252 (252-51.el9_6.4)
+PAM +AUDIT +SELINUX -APPARMOR +IMA +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL
+ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN -IPTC +KMOD +LIBCRYPTSETUP
+LIBFDISK +PCRE2 -PWQUALITY +P11KIT -QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB
+ZSTD -BPF_FRAMEWORK +XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified
```


[Slack Thread](https://redhat-internal.slack.com/archives/C07UFEUD732/p1768915990638039)

With the initiative to use ubi-minimal images, `systemd` installation is required to provide`journalctl` binary.
This is currently successfully building out of my [fork](https://github.com/openshift-eng/ocp-build-data/blob/logging-6.3/images/vector.yml#L8) [here](https://github.com/rayfordj/vector/blob/v0.47.0-rh/Dockerfile.art#L23).  Once the PR merges, we'll revert to using the ViaQ/vector repository again for building vector (with systemd).
