### PR TITLE
LOG-8584: Update Dockerfile.art labels

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -42,7 +42,6 @@ LABEL \
         maintainer="AOS Logging <team-logging@redhat.com>" \
         name="openshift-logging/vector-rhel9" \
         summary="Log collection agent for Red Hat Openshift Logging" \
-        url=${VECTOR_URL} \
         vendor="Red Hat, Inc." \
         version_minor="v0.47" \
         version="v0.47.0"


### PR DESCRIPTION
**Description**
If a URL is not defined in the Dockerfile, ART will automatically add the URL label  with value "https://catalog.redhat.com/en/search?searchType=containers". 

**Links**

JIRA: https://issues.redhat.com/browse/LOG-8584

