### PR TITLE
Update Dockerfile used for ART to match environment

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9-6-els/rhel:9.6@sha256:79408df6a94a716af2f2bd6aff681e33c7c91691ac128a0c5fb90b423dbd48ad AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
 
 RUN INSTALL_PKGS=" \
       gcc-c++ \
@@ -7,7 +7,7 @@ RUN INSTALL_PKGS=" \
       openssl-devel \
       rust-toolset-1.84.1 \
       " && \
-    dnf install -y $INSTALL_PKGS && \
+    microdnf install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS
 
 COPY . /opt/app-root/src
@@ -17,32 +17,27 @@ RUN PROTOC=/opt/app-root/src/thirdparty/protoc/protoc-linux-$(arch) make build-o
 
 RUN cp /opt/app-root/src/target/release/vector /usr/bin
 
-FROM registry.redhat.io/rhel9-6-els/rhel:9.6@sha256:79408df6a94a716af2f2bd6aff681e33c7c91691ac128a0c5fb90b423dbd48ad
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 COPY --from=builder /usr/bin/vector /usr/bin/
-RUN dnf install -y systemd
+RUN microdnf install -y systemd
 
 WORKDIR /usr/bin
 CMD ["/usr/bin/vector"]
 
-ARG VECTOR_URL
-ARG VECTOR_COMMIT
 LABEL \
         com.redhat.component="logging-vector-container" \
         description="Vector container for collection of container logs" \
         distribution-scope="subscription" \
         io.k8s.description="Vector container for collection of container logs" \
         io.k8s.display-name="Vector" \
-        io.openshift.build.commit.id=${VECTOR_COMMIT} \
-        io.openshift.build.commit.url=${VECTOR_URL}/commit/${VECTOR_COMMIT} \
-        io.openshift.build.source-location=${VECTOR_URL} \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.tags="logging,vector,observability" \
         license="Apache-2.0" \
         maintainer="AOS Logging <team-logging@redhat.com>" \
         name="openshift-logging/vector-rhel9" \
         summary="Log collection agent for Red Hat Openshift Logging" \
-        url=${VECTOR_URL} \
+        url="https://catalog.redhat.com/en/software/containers/openshift-logging/vector-rhel9/6447991f84aeefde2c9f2bcf" \
         vendor="Red Hat, Inc." \
         version_minor="v0.47" \
         version="v0.47.0"


### PR DESCRIPTION
Updates the Dockerfile to use UBI9-minimal which is what is used in ART. It also replaces the usage of `dnf` with `microdnf` because the former does not exist in `ubi-minimal`. This seems to work locally, but I wonder why the version with `dnf` is successful on ART.

Questions:

- [x] How does this work in ART that it uses `dnf` but has `ubi9-minimal` as base-image?
    - It's not actually using "bare ubi9-minimal". The actual base image has a wrapper script converting from dnf to microdnf.
    - This means it should be safe to just directly use `microdnf` in our Dockerfile.

Supersedes: #240 

/cc @jcantrill 
/hold until we know how it works in ART?