### PR TITLE
[v0.54.0]fix(deps): update lz4_flex dependency to 0.11.6 to fix CVE-2026-32829

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6503,9 +6503,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]


### PR DESCRIPTION
 The impact is potential exposure of sensitive data and secrets through crafted or malformed LZ4 input.
 This issue has been fixed in versions `0.11.6`.
https://rustsec.org/advisories/RUSTSEC-2026-0041