### PR TITLE
[v0.54.0]fix(deps): upgrade quinn-proto to 0.11.14 to patch CVE-2026-31812

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6464,6 +6464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lua-src"
 version = "547.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8744,13 +8750,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes 1.11.1",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls 0.23.23",


### PR DESCRIPTION
 Upgrades quinn-proto from 0.11.9 to 0.11.14 which fixes a remote denial of service vulnerability (CVE-2026-31812).
 The vulnerability allowed unauthenticated attackers to trigger a panic in the QUIC transport parameter parsing
 by sending a crafted Initial packet with malformed varint encodings. The fix replaces unsafe unwrap() calls with proper error handling.
Fixes: CVE-2026-31812
See: [RUSTSEC-2026-0037](https://rustsec.org/advisories/RUSTSEC-2026-0037)